### PR TITLE
Fix Makefile Indexing

### DIFF
--- a/external.mk
+++ b/external.mk
@@ -1,1 +1,1 @@
-include $(sort $(wildcard $(BR2_EXTERNAL_DPDK)/package/*/*.mk))
+include $(sort $(wildcard $(BR2_EXTERNAL_DPDK_PATH)/package/*/*.mk))


### PR DESCRIPTION
Updated ''external.mk'' to use the correct BR2 variable for this external tree.